### PR TITLE
docs: fix deploy docs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -33,7 +33,7 @@ If you're opting for a manual installation, follow these steps:
 
 6. Install additional necessary packages using pip3:
     ```bash
-    pip3 install pypose open3d opencv-python rosnumpy
+    pip3 install pypose open3d opencv-python rosnumpy empy
     ```
 
 ## Installation Using a YAML File

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,9 +26,9 @@ If you're opting for a manual installation, follow these steps:
     conda install -c anaconda numpy==1.23.5 nbconvert
     ```
 
-5. Install rospkg, wandb, and PyYAML from the conda-forge channel using the command:
+5. Install rospkg, protobuf, wandb, and PyYAML from the conda-forge channel using the command:
     ```bash
-    conda install -c conda-forge rospkg wandb pyyaml==6.0
+    conda install -c conda-forge rospkg protobuf==3.20.1 wandb pyyaml==6.0
     ```
 
 6. Install additional necessary packages using pip3:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,7 +18,7 @@ If you're opting for a manual installation, follow these steps:
 
 3. Install PyTorch and Torchvision using the command:
     ```bash
-    conda install pytorch torchvision pytorch-cuda=11.8 -c pytorch -c nvidia
+    conda install pytorch torchvision==0.15.2 pytorch-cuda=11.8 -c pytorch -c nvidia
     ```
 
 4. Install numpy version 1.23.5 using conda:

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Once you have the training data ready, use the following command to start the tr
 
 Launch the simulation environment without the default local planner
 
-    roslaunch vehicle_simulator simulation_env.launch
+    roslaunch vehicle_simulator <simulation_env>.launch
 
 Run the iPlanner ROS node without visualization:
 


### PR DESCRIPTION
1. modify the ambiguity of `simulation_env.launch` in README
    The `simulation_env.launch` is not a launch file of `vehicle_simulator`, need to be replaced with a placeholder.
2. add empy in INSTALL.md
3. torchvision==0.15.2
    To fix `RuntimeError: operator torchvision::nms does not exist`
4. protobuf==3.20.1
    To fix `AttributeError: module 'wandb.proto.wandb_internal_pb2' has no attribute 'Result'`